### PR TITLE
switch to trusted publishing for npmjs.com

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,16 @@ jobs:
           node-version: "20.x"
           # registry-url is required for releasing packages
           registry-url: "https://registry.npmjs.org"
+
+      - name: Install latest npm cli
+        run: npm install -g npm@latest
+
       - run: npm install
 
       - run: npm run test
 
       - name: Publish package
-        # --provenance enables the automatic generation of provenance statements
+        # --provenance enables the automatic generation of provenance statements (when using trusted publisher, this is automatically enabled and therefore optional)
         # --access public is only hard required for the initial release, but it doesn't hurt having it setup
+        # npm version >=11.5.1 required for trusted publisher
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This Pull Request updates the release workflow to utilize npmjs.com's [trusted publishing](https://docs.npmjs.com/trusted-publishers). 

As trusted publishing requires npm CLI version `>=11.5.1`, we manually install the latest version since the default installed npm version is insufficient.

This change eliminates the need for a static `NPM_TOKEN` secret, instead using short-lived OIDC identity tokens for authentication and package upload.

The necessary setup on npmjs.com has already been completed.
<img width="809" height="233" alt="grafik" src="https://github.com/user-attachments/assets/9010ea7e-297b-4ccd-8b47-0376c2fa95ee" />

