### PR TITLE
Set Node v22 as a min version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ">=22.22.0"
 
       - name: Install NPM dependencies
         run: npm install
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: ">=22.22.0"
 
       - name: Install NPM dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "main": "configs/index.js",
   "engines": {
-    "node": ">=20.19.0",
+    "node": ">=22.22.0",
     "npm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Node v20 is out of maintenance in April 2026, hence, setting Node version to a minimal LTS.