### PR TITLE
Update GH Actions to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,9 +11,9 @@ jobs:
     name: Static linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ">=22.22.0"
 
@@ -30,9 +30,9 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ">=22.22.0"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Package to NPMJS.org
+name: Release
 on:
   workflow_dispatch:
 jobs:
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: npmjs:@sap/eslint-config
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20.x"
+          node-version: ">=22.22.0"
           # registry-url is required for releasing packages
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
Old GH Actions are using Node v20 which is out of maintenance.